### PR TITLE
Fixed scm_api depends issue (#507)

### DIFF
--- a/conf.d/20plugins
+++ b/conf.d/20plugins
@@ -7,7 +7,7 @@ dl() {
 
 SRC=/usr/local/src
 
-PLUGINS="git git-client bazaar mercurial"
+PLUGINS="scm-api git git-client bazaar mercurial"
 PLUGINS_DIR="/var/lib/jenkins/plugins"
 mkdir -p $PLUGINS_DIR
 


### PR DESCRIPTION
Closes https://github.com/turnkeylinux/tracker/issues/507 as per suggested workaround.
