### PR TITLE
Fix reverse proxy set up is broken

### DIFF
--- a/conf.d/40apache
+++ b/conf.d/40apache
@@ -2,6 +2,7 @@
 
 a2enmod proxy
 a2enmod proxy_http
+a2enmod headers
 a2enmod vhost_alias
 
 a2dissite 000-default

--- a/overlay/etc/apache2/sites-available/jenkins.conf
+++ b/overlay/etc/apache2/sites-available/jenkins.conf
@@ -3,24 +3,23 @@ ServerName localhost
 <VirtualHost *:80>
     UseCanonicalName Off
     ServerAdmin  webmaster@localhost
-    <Proxy *>
-        Order deny,allow
-        Allow from all
-    </Proxy>
-    ProxyPass / http://localhost:8080/
-    ProxyPassReverse / http://localhost:8080/
-    ProxyRequests Off
+    Redirect permanent / https://localhost/
 </VirtualHost>
 
 <VirtualHost *:443>
     SSLEngine on
+    UseCanonicalName Off
     ServerAdmin  webmaster@localhost
+    ProxyRequests Off
+    ProxyPreserveHost On
+    AllowEncodedSlashes NoDecode
     <Proxy *>
         Order deny,allow
         Allow from all
     </Proxy>
-    ProxyPass / http://localhost:8080/
+    ProxyPass / http://localhost:8080/ nocanon
     ProxyPassReverse / http://localhost:8080/
-    ProxyRequests Off
+    RequestHeader set X-Forwarded-Proto "https"
+    RequestHeader set X-Forwarded-Port "443"
 </VirtualHost>
 


### PR DESCRIPTION
Fix Jenkins alert that reverse proxy set up is broken, but also permanently redirect http to https.
I used a modified version of the jenkins.conf for TurnKey Linux from the Jenkins Wiki, https://wiki.jenkins-ci.org/display/JENKINS/Running+Jenkins+behind+Apache.  It seems to be working okay without specifying the full domain name but for some installations it may be necessary to include the fqdn during firstboot.

```
Redirect permanent / https://www.example.com/
...
ProxyPassReverse  /  http://www.example.com/
```
