### PR TITLE
Fix redirect from http://addr to https://localhost

### DIFF
--- a/conf.d/40apache
+++ b/conf.d/40apache
@@ -4,6 +4,7 @@ a2enmod proxy
 a2enmod proxy_http
 a2enmod headers
 a2enmod vhost_alias
+a2enmod rewrite
 
 a2dissite 000-default
 a2ensite jenkins

--- a/overlay/etc/apache2/sites-available/jenkins.conf
+++ b/overlay/etc/apache2/sites-available/jenkins.conf
@@ -2,14 +2,13 @@ ServerName localhost
 
 <VirtualHost *:80>
     UseCanonicalName Off
-    ServerAdmin  webmaster@localhost
-    Redirect permanent / https://localhost/
+    RewriteEngine on
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301,QSA]
 </VirtualHost>
 
 <VirtualHost *:443>
     SSLEngine on
     UseCanonicalName Off
-    ServerAdmin  webmaster@localhost
     ProxyRequests Off
     ProxyPreserveHost On
     AllowEncodedSlashes NoDecode


### PR DESCRIPTION
The appliance looked broken because its http site redirected users to localhost.

It cannot be done correctly using mod_redirect, unless populated from APP_DOMAIN inithooks variable. mod_rewrite is universal.
