### PR TITLE
Plugins and cli

### DIFF
--- a/changelog
+++ b/changelog
@@ -4,6 +4,14 @@ turnkey-jenkins-14.2 (1) turnkey; urgency=low
 
   * Upgraded to OpenJDK v8.
 
+  * jenkins-cli:
+
+    - '-remoter' mode disabled by default (security) 
+    - JENKINS_URL env var set to http://localhost:8080 (convenience)
+    - jenkins-cli bash wrapper - can now use 'jenkins-cli' instead of
+      'java -jar path/to/jenkins-cli.jar' (convenience)
+    [jeremy@turnkeylinux.org]
+
   * Note: Please refer to turnkey-core's changelog for changes common to all
     appliances. Here we only describe changes specific to this appliance.
 

--- a/conf.d/20plugins
+++ b/conf.d/20plugins
@@ -7,7 +7,7 @@ dl() {
 
 SRC=/usr/local/src
 
-PLUGINS="scm-api git git-client bazaar mercurial pam-auth"
+PLUGINS="scm-api structs git workflow-step-api workflow-scm-step credentials git-client ssh-credentials bazaar mercurial matrix-project pam-auth junit script-security mailer display-url-api"
 PLUGINS_DIR="/var/lib/jenkins/plugins"
 mkdir -p $PLUGINS_DIR
 

--- a/conf.d/50cli
+++ b/conf.d/50cli
@@ -1,0 +1,32 @@
+#!/bin/bash -ex
+
+# set cli for easy local use
+
+JENKINS_PATH=/var/lib/jenkins
+CLI_PATH=/var/cache/jenkins/war/WEB-INF/jenkins-cli.jar
+
+cat > /usr/local/bin/jenkins-cli <<EOF
+#!/bin/bash -e
+
+java -jar $CLI_PATH $@
+
+EOF
+
+chmod +x /usr/local/bin/jenkins-cli
+
+cat > /root/.bashrc.d/jenkins <<EOF
+export JENKINS_URL=http://localhost:8080
+
+EOF
+
+chmod +x /root/.bashrc.d/jenkins
+
+# disable -remoting mode (security)
+
+cat > $JENKINS_PATH/jenkins.CLI.xml <<EOF
+<?xml version='1.0' encoding='UTF-8'?>
+<jenkins.CLI>
+  <enabled>false</enabled>
+</jenkins.CLI>
+EOF
+


### PR DESCRIPTION
Jenkins appears to not be able to auto manage plugin dependencies, so I explicitly added the required deps.

Also while I was mucking around I checked out the cli client. I set it up for easy local use; it can now be accessed locally via `jenkins-cli` (rather than needing `java -jar path/to/jenkins-cli.jar`). I also set `JENKINS_URL` to `http://localhost:8080` by default. '-remoter' mode has also been disabled (security).

E.g.:
````
root@jenkins ~# jenkins-cli version
2.60.1
````
